### PR TITLE
Removes dropRight to filter the sum returned by the tool.

### DIFF
--- a/src/main/scala/codacy/metrics/Cloc.scala
+++ b/src/main/scala/codacy/metrics/Cloc.scala
@@ -18,7 +18,7 @@ object Cloc extends MetricsTool {
                      options: Map[MetricsConfiguration.Key, MetricsConfiguration.Value]): Try[List[FileMetrics]] = {
 
     getLinesCount(source.path, files).map { metricsSeq =>
-      metricsSeq.dropRight(1).map { clocFileMetrics =>
+      metricsSeq.map { clocFileMetrics =>
         FileMetrics(
           filename = clocFileMetrics.filename,
           loc = Option(clocFileMetrics.linesOfCode),
@@ -33,7 +33,7 @@ object Cloc extends MetricsTool {
     result.map { json =>
       for {
         metricsMap <- json.asOpt[Map[String, JsValue]].toList
-        (file, metrics) <- metricsMap
+        (file, metrics) <- metricsMap if file.startsWith(targetDirectory)
         linesOfCode <- (metrics \ "code").asOpt[Int]
         linesOfComments <- (metrics \ "comment").asOpt[Int]
         blankLines <- (metrics \ "blank").asOpt[Int]


### PR DESCRIPTION
 It now checks if the filename starts by the targetDirectory path.