### PR TITLE
Fix inputs handling (IO-47)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -88,3 +88,6 @@ project/plugins/project/
 .DS_Store
 
 node_modules
+
+.bloop
+.metals

--- a/src/main/scala/codacy/metrics/Cloc.scala
+++ b/src/main/scala/codacy/metrics/Cloc.scala
@@ -7,7 +7,7 @@ import com.codacy.plugins.api.metrics.{FileMetrics, MetricsTool}
 import com.codacy.plugins.api.{Options, Source}
 import play.api.libs.json._
 
-import scala.util.Try
+import scala.util.{Success, Try}
 
 final case class ClocFileMetrics(filename: String, linesOfCode: Int, linesOfComments: Int, blankLines: Int)
 
@@ -18,7 +18,16 @@ object Cloc extends MetricsTool {
                      files: Option[Set[Source.File]],
                      options: Map[Options.Key, Options.Value]): Try[List[FileMetrics]] = {
 
-    getLinesCount(source.path, files).map { metricsSeq =>
+    // If a file is empty in the files array given explictly to the tool with the codacyrc,
+    // example: files: [ "" ], it prepends the /src part of the path
+    // and the tool will execute for the whole folder accidentally...
+    // We clean up that erroneous case so that we protect ourselves from potential
+    // problems when the tool is called for example with
+    // files: [ "README.md", "" ] by some mistake,
+    // where we only wanted to process the explicit files, in this case only "README.md"
+    val cleanedUpFiles = files.map(_.excl(Source.File("/src")))
+
+    getLinesCount(source.path, cleanedUpFiles).map { metricsSeq =>
       metricsSeq.map { clocFileMetrics =>
         FileMetrics(
           filename = clocFileMetrics.filename,
@@ -34,39 +43,66 @@ object Cloc extends MetricsTool {
     def stripBaseDir(filePath: String) =
       filePath.stripPrefix("./")
 
-    result.map { json =>
-      for {
-        metricsMap <- json.asOpt[Map[String, JsValue]].toList
-        (file, metrics) <- metricsMap if (targetDirectory / file).exists
-        linesOfCode <- (metrics \ "code").asOpt[Int]
-        linesOfComments <- (metrics \ "comment").asOpt[Int]
-        blankLines <- (metrics \ "blank").asOpt[Int]
-      } yield {
-        ClocFileMetrics(stripBaseDir(file), linesOfCode, linesOfComments, blankLines)
+    result.map { jsonOpt =>
+      jsonOpt.fold(List.empty[ClocFileMetrics]) { json =>
+        for {
+          metricsMap <- json.asOpt[Map[String, JsValue]].toList
+          (file, metrics) <- metricsMap if (targetDirectory / file).exists
+          linesOfCode <- (metrics \ "code").asOpt[Int]
+          linesOfComments <- (metrics \ "comment").asOpt[Int]
+          blankLines <- (metrics \ "blank").asOpt[Int]
+        } yield {
+          ClocFileMetrics(stripBaseDir(file), linesOfCode, linesOfComments, blankLines)
+        }
       }
     }
   }
 
-  private def commandResult(targetDirectory: String, files: Option[Set[Source.File]]): Try[JsValue] = {
+  private def commandResult(targetDirectory: String, files: Option[Set[Source.File]]): Try[Option[JsValue]] = {
     val commandRes = baseCommand(targetDirectory, files)
 
+    // It's a valid output of the tool to exit with no errors but still have the
+    // output as empty. Example: asking the tool to analyze a file that
+    // doesn't exist will terminnte with 0 and empty output.
+    // We shouldn't try to parse empty string since that's not valid json anyway.
+
     commandRes.flatMap { fullOutput =>
-      Try(Json.parse(fullOutput.mkString))
+      val finalOutput: String = fullOutput.mkString
+
+      if (finalOutput.nonEmpty) {
+        Try(Json.parse(finalOutput)).map(Some(_))
+      } else {
+        Success(None)
+      }
     }
   }
 
   private def baseCommand(targetDirectory: String, filesOpt: Option[Set[Source.File]]): Try[List[String]] = {
     val targetDir = new java.io.File(targetDirectory)
 
-    val clocTarget = filesOpt.fold(Set("."))(_.map(_.path))
+    val clocTarget = filesOpt.fold {
+      Set[String](".")
+    } { _.map(_.path) }
 
-    val commandResult =
-      CommandRunner.exec(List("cloc", "--json", "--by-file", "--skip-uniqueness") ++ clocTarget, Some(targetDir))
+    // TODO: problem, if the SET is empty, which is possible by giving files: [] in the codacyrc
+    // file, then the tool fails since clocTarget expands to "" and the tool errors out without knowing
+    // what to analyze when being called.
+    // temporary protection by just not running the tool, since we are being told to run the tool
+    // for exactly 0 files, maybe that's what should be expected???
+    // just need to confirm this is what we want
 
-    resolveErrors(commandResult, clocTarget)
+    if (clocTarget.isEmpty) {
+      Success(List.empty)
+    } else {
+      val commandResult =
+        CommandRunner.exec(List("cloc", "--json", "--by-file", "--skip-uniqueness") ++ clocTarget, Some(targetDir))
+
+      handleCommandResult(commandResult, clocTarget)
+    }
   }
 
-  private def resolveErrors(either: Either[Throwable, CommandResult], targetFiles: Set[String]): Try[List[String]] = {
+  private def handleCommandResult(either: Either[Throwable, CommandResult],
+                                  targetFiles: Set[String]): Try[List[String]] = {
     either match {
       case Left(throwable)                    => scala.util.Failure(throwable)
       case Right(CommandResult(0, stdOut, _)) => scala.util.Success(stdOut)

--- a/src/main/scala/codacy/metrics/Cloc.scala
+++ b/src/main/scala/codacy/metrics/Cloc.scala
@@ -63,7 +63,7 @@ object Cloc extends MetricsTool {
 
     // It's a valid output of the tool to exit with no errors but still have the
     // output as empty. Example: asking the tool to analyze a file that
-    // doesn't exist will terminnte with 0 and empty output.
+    // doesn't exist will terminate with 0 and empty output.
     // We shouldn't try to parse empty string since that's not valid json anyway.
 
     commandRes.flatMap { fullOutput =>
@@ -84,12 +84,9 @@ object Cloc extends MetricsTool {
       Set[String](".")
     } { _.map(_.path) }
 
-    // TODO: problem, if the SET is empty, which is possible by giving files: [] in the codacyrc
-    // file, then the tool fails since clocTarget expands to "" and the tool errors out without knowing
-    // what to analyze when being called.
-    // temporary protection by just not running the tool, since we are being told to run the tool
-    // for exactly 0 files, maybe that's what should be expected???
-    // just need to confirm this is what we want
+    // If the files Set is empty, which is possible by giving files: [] in the codacyrc,
+    // then the tool fails since clocTarget expands to "" and the tool itself errors out.
+    // Protecting the call to ensure the tool is NOT called when files to process are empty.
 
     if (clocTarget.isEmpty) {
       Success(List.empty)


### PR DESCRIPTION
The cloc / metrics tool receives files to be run from the usual .codacyrc file.

I found some issues regarding it and this attempts to resolve them:
 * when passed a list of files that do not exist, example `files: [ "something", "foo" ]`, then the tool seems to completely ignore them and really just reports info when it really finds files. In general it seems a good approach, but we get a case where if we only pass a list of files that don't exist then the output of the tool is totally empty, which can't be parsed as valid json;
 * when passing the files and if accidentally we add an empty string then currently it is triggering the analysis of the whole /src anyway. This happens because after the codacyrc is parsed we add the prefix of /src to all files so when it reaches the call to cloc it will find that "path" and analyze everything. Example: `files: [ "something", "foo", "" ]`;
 * when the files is passed by the codacyrc but the array is empty then we get an emtpy Set of paths, which when passed to the cloc call ends up being and empty string and the cloc tool fails when it is not being given an explicit thing to analyze. Example: `files: [ ]`

The following cases can be checked by running the cloc tool directly in any repo/directory:
 * ```
   cloc --by-file --skip-uniqueness something foo
       0 text files.
       0 unique files.                              
       0 files ignored.

   2 errors:
   Unable to read:  something
   Unable to read:  foo
   ```
   exit code of the tool is 0;

 * ```
   cloc --by-file --skip-uniqueness 
       ... help / usage of the tool is dumped ...
   ```
   exit code of the tool is 2;
